### PR TITLE
NEXTPY-2431 -- Test compatible with Python 3.11, 3.12 & 3.13 and Django 4.2 & 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11"]
-        DJANGO: ["3.2", "4.2"]
+        python-version: ["3.11", "3.12", "3.13"]
+        DJANGO: ["4.2", "5.2"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,24 @@ language: python
 cache: pip
 
 python:
-  - "3.9"
   - "3.11"
+  - "3.12"
+  - "3.13"
 
 env:
   matrix:
-    - DJANGO=3.2
     - DJANGO=4.2
+    - DJANGO=5.2
 
 matrix:
   fast_finish: true
   include:
     - { python: "3.11", env: TOXENV=isort }
     - { python: "3.11", env: TOXENV=black }
-    # - { python: "3.11", env: TOXENV=docs }
+    - { python: "3.12", env: TOXENV=isort }
+    - { python: "3.12", env: TOXENV=black }
+    - { python: "3.13", env: TOXENV=isort }
+    - { python: "3.13", env: TOXENV=black }
 
 install:
   - pip install tox tox-travis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make `djangorestframework-inclusions` compatible with Python 3.11, 3.12, 3.13 and both Django 4.2 and 5.2
 
 
 1.2.0 (2023-09-22)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,14 +14,15 @@ keywords = API, REST, lazy loading, django, djangorestframework
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
-    Framework :: Django :: 3.2
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,311}-django{32,42}
+    py{311,313,313}-django{42,52}
     isort
     black
     ; docs
@@ -8,16 +8,16 @@ skip_missing_interpreters = true
 
 [travis:env]
 DJANGO =
-    3.2: django32
     4.2: django42
+    5.2: django52
 
 [testenv]
 extras =
     tests
     coverage
 deps =
-  django32: Django>=3.2,<4.0
   django42: Django>=4.2,<5.0
+  django52: Django>=5.2,<6.0
 commands =
   py.test tests \
    --junitxml=reports/junit.xml \


### PR DESCRIPTION
Compatbility with Python 3.11/12/13 and Django 4.2/5.2
- Tested compatibility with Python 3.11, 3.12 and 3.13
- Tested compatibility with Django 4.2 and 5.2

No changes necessary, the warning does not apply to us;
# RemovedInDjango50Warning
# https://docs.djangoproject.com/en/dev/releases/5.0/#features-removed-in-5-0
# The default value of the USE_TZ setting is changed from False to True.

tox output for all 6 scenarios;
---------
koen@Koens-MacBook-Pro djangorestframework-inclusions % tox
py311-django42: recreate env because python changed version_info=[3, 11, 4, 'final', 0]->[3, 11, 13, 'final', 0] | executable='/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11'->'/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/bin/python3.11' | virtualenv version='20.24.3'->'20.34.0'
py311-django42: remove tox env folder /Users/koen/code/djangorestframework-inclusions/.tox/py311-django42
py311-django42: install_deps> python -I -m pip install 'Django<5.0,>=4.2'
.pkg: recreate env because python changed version_info=[3, 11, 4, 'final', 0]->[3, 11, 13, 'final', 0] | executable='/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11'->'/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/bin/python3.11' | virtualenv version='20.24.3'->'20.34.0'
.pkg: remove tox env folder /Users/koen/code/djangorestframework-inclusions/.tox/.pkg
.pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0'
.pkg: _optional_hooks> python /Users/koen/.virtualenvs/drfi_311/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /Users/koen/.virtualenvs/drfi_311/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /Users/koen/.virtualenvs/drfi_311/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /Users/koen/.virtualenvs/drfi_311/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Users/koen/.virtualenvs/drfi_311/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py311-django42: install_package_deps> python -I -m pip install black django djangorestframework isort pytest pytest-cov pytest-django tox
py311-django42: install_package> python -I -m pip install --force-reinstall --no-deps /Users/koen/code/djangorestframework-inclusions/.tox/.tmp/package/17/djangorestframework_inclusions-1.2.1.dev0.tar.gz
py311-django42: commands[0]> py.test tests --junitxml=reports/junit.xml --cov --cov-report xml:reports/coverage-py311-django42.xml
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.11.13, pytest-8.4.1, pluggy-1.6.0
cachedir: .tox/py311-django42/.pytest_cache
django: version: 4.2.23, settings: testapp.settings (from ini)
rootdir: /Users/koen/code/djangorestframework-inclusions
configfile: setup.cfg
plugins: django-4.11.1, cov-6.2.1
collected 38 items

tests/test_basic.py .......                                                                                                                                                                                                                   [ 18%]
tests/test_chained_loading.py ..s...                                                                                                                                                                                                          [ 34%]
tests/test_references.py .........................                                                                                                                                                                                            [100%]

================================================================================================================= warnings summary ==================================================================================================================
.tox/py311-django42/lib/python3.11/site-packages/django/conf/__init__.py:241
  /Users/koen/code/djangorestframework-inclusions/.tox/py311-django42/lib/python3.11/site-packages/django/conf/__init__.py:241: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------- generated xml file: /Users/koen/code/djangorestframework-inclusions/reports/junit.xml -------------------------------------------------------------------------------
================================================================================================================== tests coverage ===================================================================================================================
_________________________________________________________________________________________________ coverage: platform darwin, python 3.11.13-final-0 _________________________________________________________________________________________________

Coverage XML written to file reports/coverage-py311-django42.xml
===================================================================================================== 37 passed, 1 skipped, 1 warning in 1.26s ======================================================================================================
py311-django42: OK ✔ in 27.82 seconds
py311-django52: install_deps> python -I -m pip install 'Django<6.0,>=5.2'
py311-django52: install_package_deps> python -I -m pip install black django djangorestframework isort pytest pytest-cov pytest-django tox
py311-django52: install_package> python -I -m pip install --force-reinstall --no-deps /Users/koen/code/djangorestframework-inclusions/.tox/.tmp/package/18/djangorestframework_inclusions-1.2.1.dev0.tar.gz
py311-django52: commands[0]> py.test tests --junitxml=reports/junit.xml --cov --cov-report xml:reports/coverage-py311-django52.xml
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.11.13, pytest-8.4.1, pluggy-1.6.0
cachedir: .tox/py311-django52/.pytest_cache
django: version: 5.2.5, settings: testapp.settings (from ini)
rootdir: /Users/koen/code/djangorestframework-inclusions
configfile: setup.cfg
plugins: django-4.11.1, cov-6.2.1
collected 38 items

tests/test_basic.py .......                                                                                                                                                                                                                   [ 18%]
tests/test_chained_loading.py ..s...                                                                                                                                                                                                          [ 34%]
tests/test_references.py .........................                                                                                                                                                                                            [100%]

------------------------------------------------------------------------------- generated xml file: /Users/koen/code/djangorestframework-inclusions/reports/junit.xml -------------------------------------------------------------------------------
================================================================================================================== tests coverage ===================================================================================================================
_________________________________________________________________________________________________ coverage: platform darwin, python 3.11.13-final-0 _________________________________________________________________________________________________

Coverage XML written to file reports/coverage-py311-django52.xml
=========================================================================================================== 37 passed, 1 skipped in 1.22s ===========================================================================================================
py311-django52: OK ✔ in 23.48 seconds
py313-django42: install_deps> python -I -m pip install 'Django<5.0,>=4.2'
py313-django42: install_package_deps> python -I -m pip install black django djangorestframework isort pytest pytest-cov pytest-django tox
py313-django42: install_package> python -I -m pip install --force-reinstall --no-deps /Users/koen/code/djangorestframework-inclusions/.tox/.tmp/package/19/djangorestframework_inclusions-1.2.1.dev0.tar.gz
py313-django42: commands[0]> py.test tests --junitxml=reports/junit.xml --cov --cov-report xml:reports/coverage-py313-django42.xml
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.13.6, pytest-8.4.1, pluggy-1.6.0
cachedir: .tox/py313-django42/.pytest_cache
django: version: 4.2.23, settings: testapp.settings (from ini)
rootdir: /Users/koen/code/djangorestframework-inclusions
configfile: setup.cfg
plugins: django-4.11.1, cov-6.2.1
collected 38 items

tests/test_basic.py .......                                                                                                                                                                                                                   [ 18%]
tests/test_chained_loading.py ..s...                                                                                                                                                                                                          [ 34%]
tests/test_references.py .........................                                                                                                                                                                                            [100%]

================================================================================================================= warnings summary ==================================================================================================================
.tox/py313-django42/lib/python3.13/site-packages/django/conf/__init__.py:241
  /Users/koen/code/djangorestframework-inclusions/.tox/py313-django42/lib/python3.13/site-packages/django/conf/__init__.py:241: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------- generated xml file: /Users/koen/code/djangorestframework-inclusions/reports/junit.xml -------------------------------------------------------------------------------
================================================================================================================== tests coverage ===================================================================================================================
_________________________________________________________________________________________________ coverage: platform darwin, python 3.13.6-final-0 __________________________________________________________________________________________________

Coverage XML written to file reports/coverage-py313-django42.xml
===================================================================================================== 37 passed, 1 skipped, 1 warning in 1.17s ======================================================================================================
py313-django42: OK ✔ in 24.04 seconds
py313-django52: install_deps> python -I -m pip install 'Django<6.0,>=5.2'
py313-django52: install_package_deps> python -I -m pip install black django djangorestframework isort pytest pytest-cov pytest-django tox
py313-django52: install_package> python -I -m pip install --force-reinstall --no-deps /Users/koen/code/djangorestframework-inclusions/.tox/.tmp/package/20/djangorestframework_inclusions-1.2.1.dev0.tar.gz
py313-django52: commands[0]> py.test tests --junitxml=reports/junit.xml --cov --cov-report xml:reports/coverage-py313-django52.xml
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.13.6, pytest-8.4.1, pluggy-1.6.0
cachedir: .tox/py313-django52/.pytest_cache
django: version: 5.2.5, settings: testapp.settings (from ini)
rootdir: /Users/koen/code/djangorestframework-inclusions
configfile: setup.cfg
plugins: django-4.11.1, cov-6.2.1
collected 38 items

tests/test_basic.py .......                                                                                                                                                                                                                   [ 18%]
tests/test_chained_loading.py ..s...                                                                                                                                                                                                          [ 34%]
tests/test_references.py .........................                                                                                                                                                                                            [100%]

------------------------------------------------------------------------------- generated xml file: /Users/koen/code/djangorestframework-inclusions/reports/junit.xml -------------------------------------------------------------------------------
================================================================================================================== tests coverage ===================================================================================================================
_________________________________________________________________________________________________ coverage: platform darwin, python 3.13.6-final-0 __________________________________________________________________________________________________

Coverage XML written to file reports/coverage-py313-django52.xml
=========================================================================================================== 37 passed, 1 skipped in 1.20s ===========================================================================================================
py313-django52: OK ✔ in 20.05 seconds
isort: recreate env because python changed version_info=[3, 11, 4, 'final', 0]->[3, 11, 13, 'final', 0] | executable='/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11'->'/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/bin/python3.11' | virtualenv version='20.24.3'->'20.34.0'
isort: remove tox env folder /Users/koen/code/djangorestframework-inclusions/.tox/isort
isort: install_package_deps> python -I -m pip install black django djangorestframework isort pytest pytest-django tox
isort: install_package> python -I -m pip install --force-reinstall --no-deps /Users/koen/code/djangorestframework-inclusions/.tox/.tmp/package/21/djangorestframework_inclusions-1.2.1.dev0.tar.gz
isort: commands[0]> isort --check-only --diff .
Skipped 1 files
isort: OK ✔ in 15.87 seconds
black: recreate env because python changed version_info=[3, 11, 4, 'final', 0]->[3, 11, 13, 'final', 0] | executable='/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11'->'/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/bin/python3.11' | virtualenv version='20.24.3'->'20.34.0'
black: remove tox env folder /Users/koen/code/djangorestframework-inclusions/.tox/black
black: install_package_deps> python -I -m pip install black django djangorestframework isort pytest pytest-django tox
black: install_package> python -I -m pip install --force-reinstall --no-deps /Users/koen/code/djangorestframework-inclusions/.tox/.tmp/package/22/djangorestframework_inclusions-1.2.1.dev0.tar.gz
black: commands[0]> black --check rest_framework_inclusions tests testapp docs
All done! ✨ 🍰 ✨
19 files would be left unchanged.
  py311-django42: OK (27.82=setup[22.34]+cmd[5.48] seconds)
  py311-django52: OK (23.48=setup[18.59]+cmd[4.89] seconds)
  py313-django42: OK (24.04=setup[19.30]+cmd[4.74] seconds)
  py313-django52: OK (20.05=setup[15.59]+cmd[4.45] seconds)
  isort: OK (15.87=setup[14.95]+cmd[0.92] seconds)
  black: OK (35.18=setup[30.98]+cmd[4.21] seconds)
  congratulations :) (146.53 seconds)

